### PR TITLE
Add note about versioned branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
+# go-sdk-enterprise-server
 
+Since GitHub Enterprise Server has [multiple supported versions](https://docs.github.com/en/enterprise-server/admin/all-releases) at any given time, this project uses branches to manage each version. 
+
+See [the repository's branches](https://github.com/octokit/go-sdk-enterprise-server/branches) to view your desired version. 


### PR DESCRIPTION
This is the flip side of https://github.com/octokit/dotnet-sdk-enterprise-server/pull/17. Users that land on this repository should have a note pointing them to the versioned branches with actual code/instructions.