### PR TITLE
Remove dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
-version: 2
-updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
Dependabot updates happen at the [source-generator](https://github.com/octokit/source-generator/blob/main/.github/dependabot.yml) level and are then synced downstream to this repository. This file was wasn't triggering any updates anyways since dependabot.yml needs to operate against the `main` branch.